### PR TITLE
Added supporting config for openshift

### DIFF
--- a/kubernetes/helm-hybrid/README.md
+++ b/kubernetes/helm-hybrid/README.md
@@ -164,7 +164,7 @@ kubectl get pods -n tyk-dp -w
 
 ### 6. Access Services
 
-There are three ways to access your Tyk Gateway, ordered from quickest to most production-ready:
+There are four ways to access your Tyk Gateway, ordered from quickest to most production-ready:
 
 #### Option 1: LoadBalancer Service (Quickest for Cloud Deployments)
 
@@ -392,6 +392,30 @@ ingress:
 ```
 
 **Test Gateway** at `gateway.yourdomain.com/hello`
+
+---
+
+#### Option 4: OpenShift Routes (RedHat OpenShift)
+
+OpenShift uses Routes rather than Ingress or LoadBalancer for external access. Routes are created using the `oc` CLI and are automatically assigned a hostname under your cluster's `*.apps` domain.
+
+> **For local testing on OpenShift Local (CRC), port-forwarding (Option 2) is recommended** as it avoids DNS configuration.
+
+**Expose the Gateway via a Route:**
+
+```bash
+# Expose Gateway
+oc expose svc gateway-svc-tyk-dp-tyk-gateway -n tyk-dp --port=8080
+
+# Get the assigned Route URL
+oc get routes -n tyk-dp
+```
+
+The Gateway Route will be available at a URL such as:
+
+```text
+http://gateway-svc-tyk-dp-tyk-gateway-tyk-dp.apps.<cluster-domain>
+```
 
 ---
 

--- a/kubernetes/helm-hybrid/values.yaml
+++ b/kubernetes/helm-hybrid/values.yaml
@@ -205,6 +205,25 @@ tyk-gateway:
       externalTrafficPolicy: Local
       # annotations: {}
 
+    # -------------------------------------------------------------------------
+    # Required for deploying on RedHat OpenShift
+    # -------------------------------------------------------------------------
+    # securityContext:
+    #   runAsUser: null
+    #   fsGroup: null
+    #   runAsNonRoot: true
+    # containerSecurityContext:
+    #   runAsNonRoot: true
+    #   runAsUser: null
+    #   allowPrivilegeEscalation: false
+    #   privileged: false
+    #   readOnlyRootFilesystem: true
+    #   seccompProfile:
+    #     type: RuntimeDefault
+    #   capabilities:
+    #     drop:
+    #       - ALL
+
 # PUMP (Optional but recommended)
 tyk-pump:
   pump:
@@ -223,3 +242,22 @@ tyk-pump:
       enableAggregateAnalytics: false
 
     purgeDelay: 2
+
+    # -------------------------------------------------------------------------
+    # Required for deploying on RedHat OpenShift
+    # -------------------------------------------------------------------------
+    # securityContext:
+    #   runAsUser: null
+    #   fsGroup: null
+    #   runAsNonRoot: true
+    # containerSecurityContext:
+    #   runAsNonRoot: true
+    #   runAsUser: null
+    #   allowPrivilegeEscalation: false
+    #   privileged: false
+    #   readOnlyRootFilesystem: true
+    #   seccompProfile:
+    #     type: RuntimeDefault
+    #   capabilities:
+    #     drop:
+    #       - ALL

--- a/kubernetes/helm-self-managed/README.md
+++ b/kubernetes/helm-self-managed/README.md
@@ -110,6 +110,11 @@ helm install tyk-postgres bitnami/postgresql \
   --set primary.initdb.scripts."init\.sql"="CREATE DATABASE portal;" \
   --set primary.persistence.size=20Gi \
   --version 12.12.10
+  # Required for installing on RedHat OpenShift - add the following flags:
+  # --set primary.podSecurityContext.runAsUser=null \
+  # --set primary.podSecurityContext.fsGroup=null \
+  # --set primary.containerSecurityContext.runAsUser=null \
+  # --set volumePermissions.enabled=false
 
 # Install Redis
 helm install tyk-redis oci://registry-1.docker.io/bitnamicharts/redis \
@@ -123,6 +128,7 @@ kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=postgresql -n t
 kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=redis -n tyk
 
 # Install cert-manager (required for Tyk Operator)
+# Cluster admin privileges required for installing on RedHat OpenShift
 helm install \
   cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --version v1.17.4 \
@@ -164,7 +170,7 @@ kubectl get pods -n tyk -w
 
 ### 6. Access Services
 
-There are three ways to access your Tyk services, ordered from quickest to most production-ready:
+There are four ways to access your Tyk services, ordered from quickest to most production-ready:
 
 #### Option 1: LoadBalancer Service (Quickest for Cloud Deployments)
 
@@ -479,6 +485,34 @@ tyk-dashboard:
             - dashboard.yourdomain.com
 
 # Portal (similar configuration)
+```
+
+---
+
+#### Option 4: OpenShift Routes (RedHat OpenShift)
+
+OpenShift uses Routes rather than Ingress or LoadBalancer for external access. Routes are created using the `oc` CLI and are automatically assigned a hostname under your cluster's `*.apps` domain.
+
+> **For local testing on OpenShift Local (CRC), port-forwarding (Option 2) is recommended** as it avoids DNS configuration.
+
+**Expose services via Routes:**
+
+```bash
+# Expose Dashboard, Gateway, and Portal
+oc expose svc dashboard-svc-tyk-tyk-dashboard -n tyk --port=3000
+oc expose svc gateway-svc-tyk-tyk-gateway -n tyk --port=8080
+oc expose svc dev-portal-svc-tyk-tyk-dev-portal -n tyk --port=3001
+
+# Get the assigned Route URLs
+oc get routes -n tyk
+```
+
+Routes will be available at URLs such as:
+
+```text
+http://dashboard-svc-tyk-tyk-dashboard-tyk.apps.<cluster-domain>
+http://gateway-svc-tyk-tyk-gateway-tyk.apps.<cluster-domain>
+http://dev-portal-svc-tyk-tyk-dev-portal-tyk.apps.<cluster-domain>
 ```
 
 ---

--- a/kubernetes/helm-self-managed/values.yaml
+++ b/kubernetes/helm-self-managed/values.yaml
@@ -37,7 +37,7 @@ global:
     bootstrap: true
     pump: true
     devPortal: true
-    operator: true
+    operator: true # Cluster admin rights required to install Operator (installs CRDs)
 
   servicePorts:
     dashboard: 3000
@@ -244,6 +244,25 @@ tyk-gateway:
       type: LoadBalancer
       externalTrafficPolicy: Local
 
+    # -------------------------------------------------------------------------
+    # Required for deploying on RedHat OpenShift
+    # -------------------------------------------------------------------------
+    # securityContext:
+    #   runAsUser: null
+    #   fsGroup: null
+    #   runAsNonRoot: true
+    # containerSecurityContext:
+    #   runAsNonRoot: true
+    #   runAsUser: null
+    #   allowPrivilegeEscalation: false
+    #   privileged: false
+    #   readOnlyRootFilesystem: true
+    #   seccompProfile:
+    #     type: RuntimeDefault
+    #   capabilities:
+    #     drop:
+    #       - ALL
+
 # ============================================================================
 # DASHBOARD CONFIGURATION
 # ============================================================================
@@ -373,6 +392,25 @@ tyk-dashboard:
       # Cloud-specific annotations
       # annotations: {}
 
+    # -------------------------------------------------------------------------
+    # Required for deploying on RedHat OpenShift
+    # -------------------------------------------------------------------------
+    # securityContext:
+    #   runAsUser: null
+    #   fsGroup: null
+    #   runAsNonRoot: true
+    # containerSecurityContext:
+    #   runAsNonRoot: true
+    #   runAsUser: null
+    #   allowPrivilegeEscalation: false
+    #   privileged: false
+    #   readOnlyRootFilesystem: true
+    #   seccompProfile:
+    #     type: RuntimeDefault
+    #   capabilities:
+    #     drop:
+    #       - ALL
+
   tib: # Enables SSO integration
     enabled: true
 
@@ -407,6 +445,25 @@ tyk-pump:
       #   value: "true" # PROD/PERFORMANCE: Enable table sharding
       # - name: TYK_PMP_UPTIMEPUMPCONFIG_TABLESHARDING
       #   value: "true" # PROD/PERFORMANCE: Enable table sharding
+
+    # -------------------------------------------------------------------------
+    # Required for deploying on RedHat OpenShift
+    # -------------------------------------------------------------------------
+    # securityContext:
+    #   runAsUser: null
+    #   fsGroup: null
+    #   runAsNonRoot: true
+    # containerSecurityContext:
+    #   runAsNonRoot: true
+    #   runAsUser: null
+    #   allowPrivilegeEscalation: false
+    #   privileged: false
+    #   readOnlyRootFilesystem: true
+    #   seccompProfile:
+    #     type: RuntimeDefault
+    #   capabilities:
+    #     drop:
+    #       - ALL
 
 # ============================================================================
 # DEVELOPER PORTAL CONFIGURATION
@@ -492,6 +549,25 @@ tyk-dev-portal:
     type: LoadBalancer
     port: 3001
 
+  # -------------------------------------------------------------------------
+  # Required for deploying on RedHat OpenShift
+  # -------------------------------------------------------------------------
+  # securityContext:
+  #   runAsUser: null
+  #   fsGroup: null
+  #   runAsNonRoot: true
+  # containerSecurityContext:
+  #   runAsNonRoot: true
+  #   runAsUser: null
+  #   allowPrivilegeEscalation: false
+  #   privileged: false
+  #   readOnlyRootFilesystem: true
+  #   seccompProfile:
+  #     type: RuntimeDefault
+  #   capabilities:
+  #     drop:
+  #       - ALL
+
 # ============================================================================
 # BOOTSTRAP CONFIGURATION
 # ============================================================================
@@ -503,3 +579,22 @@ tyk-bootstrap:
 
     org:
       name: "Install Organization"
+
+    # -------------------------------------------------------------------------
+    # Required for deploying on RedHat OpenShift
+    # -------------------------------------------------------------------------
+    # securityContext:
+    #   runAsUser: null
+    #   fsGroup: null
+    #   runAsNonRoot: true
+    # containerSecurityContext:
+    #   runAsNonRoot: true
+    #   runAsUser: null
+    #   allowPrivilegeEscalation: false
+    #   privileged: false
+    #   readOnlyRootFilesystem: true
+    #   seccompProfile:
+    #     type: RuntimeDefault
+    #   capabilities:
+    #     drop:
+    #       - ALL


### PR DESCRIPTION
Installing Tyk on RedHat OpenShit using Tyk Helm Charts won't work without overriding the default securityContexts.  Added required securityContexts to values file for Gateway, Dashboard, Pump, Dev Portal and Bootstrap.

Note that this change DOES NOT cover installing Operator.  Installing CRDs requires Cluster Admin rights 