### PR TITLE
chore: drop obsolete AI Studio Postgres schema workaround

### DIFF
--- a/docker/ai-studio/README.md
+++ b/docker/ai-studio/README.md
@@ -180,31 +180,6 @@ Common issues:
 1. `EDGE_AUTH_TOKEN` does not match `GRPC_AUTH_TOKEN`
 2. `ENCRYPTION_KEY` does not match `MICROGATEWAY_ENCRYPTION_KEY`
 3. AI Studio did not start successfully because TLS files are missing
-4. Existing Postgres volume was created before `utils/dbs.sql` added Microgateway compatibility domains
-
-If Microgateway fails with `type "blob" does not exist`, add the compatibility domains to the existing Microgateway database and restart Microgateway:
-
-```bash
-docker-compose exec -T postgres psql -U tykuser -d tyk_ai_microgateway <<'SQL'
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'blob') THEN
-    CREATE DOMAIN blob AS bytea;
-  END IF;
-END
-$$;
-
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'string') THEN
-    CREATE DOMAIN string AS text;
-  END IF;
-END
-$$;
-SQL
-
-docker-compose restart microgateway
-```
 
 For disposable local PoCs, you can also recreate the Postgres volume so the init script runs again:
 
@@ -212,6 +187,8 @@ For disposable local PoCs, you can also recreate the Postgres volume so the init
 docker-compose down -v
 docker-compose up -d
 ```
+
+> **Note:** Microgateway versions before `v2.1.0` required `blob`/`string` compatibility domains in the Microgateway database (`type "blob" does not exist` at startup). Since `v2.1.0` the migrations use native PostgreSQL types and no schema workaround is needed.
 
 ### Registration Returns 400
 

--- a/docker/ai-studio/utils/dbs.sql
+++ b/docker/ai-studio/utils/dbs.sql
@@ -1,21 +1,3 @@
 CREATE DATABASE tyk_ai_microgateway;
 
 GRANT ALL PRIVILEGES ON DATABASE tyk_ai_microgateway TO tykuser;
-
-\connect tyk_ai_microgateway
-
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'blob') THEN
-    CREATE DOMAIN blob AS bytea;
-  END IF;
-END
-$$;
-
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'string') THEN
-    CREATE DOMAIN string AS text;
-  END IF;
-END
-$$;


### PR DESCRIPTION
## Summary
Microgateway `v2.1.0` fixed its PostgreSQL type mapping, so the `blob`/`string` compatibility domains are no longer needed:

- `utils/dbs.sql` now only creates the `tyk_ai_microgateway` database and grant (the `CREATE DOMAIN` blocks are removed).
- The README troubleshooting section for `type "blob" does not exist` is replaced with a short historical note.

## Verification
Tested against a clean Postgres 16 with no domains, only `CREATE DATABASE` + `GRANT`:

- `tykio/tyk-microgateway:v2.1.0-rc-1` → migrations fail with `ERROR: type "blob" does not exist (SQLSTATE 42704)` on `control_payloads.payload` (confirms the old behavior).
- `tykio/tyk-microgateway:v2.1.0` → migrations complete, all 27 tables created, `payload` is native `bytea`.

Upgrades from existing rc-1 volumes are unaffected: leftover domains are harmless alongside the native-type migrations.

## Dependencies
Stacked on #34 (bumps AI Studio/Microgateway defaults to `v2.1.0`). Merge #34 first; GitHub will retarget this PR to `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)